### PR TITLE
fix tooltip overflow and z-index on mobile

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -43,7 +43,7 @@ body {
 		--background: white;
 		--light-bg: #0001;
 		--bg-green: #e8f8fa;
-		--bg-contrast: #0001;
+		--bg-contrast: #e8e8e8;
 		--bg-light-transparent: #eee5;
 		--box-shadow-light-only: 2px 2px 3px #00000038;
 	}
@@ -67,7 +67,7 @@ body {
 	--background: white;
 	--light-bg: #0001;
 	--bg-green: #e8f8fa;
-	--bg-contrast: #0001;
+	--bg-contrast: #e8e8e8;
 	--bg-light-transparent: #eee5;
 	--box-shadow-light-only: 2px 2px 3px #00000038;
 }

--- a/src/components/Tooltip/Tooltip.astro
+++ b/src/components/Tooltip/Tooltip.astro
@@ -18,10 +18,11 @@ const uniqueId = `tooltip-${Math.random().toString(36).slice(2, 8)}`;
 <style>
   .tooltip {
     width: max-content;
-    max-width: 400px;
+    max-width: min(400px, calc(100vw - 2rem));
     position: absolute;
     top: 0;
     left: 0;
+    z-index: 10;
     background: var(--bg-contrast);
     color: var(--light-foreground);
     padding: 1rem;


### PR DESCRIPTION
Cap tooltip max-width to viewport width to prevent horizontal overflow on small screens, and add z-index so the tooltip renders above article content.