### PR TITLE
add haptic feedback on navigation clicks via web-haptics

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "rehype-slug": "^5.0.1",
     "svelte": "^4.2.14",
     "typescript": "^5.4.5",
-    "vite": "^5.2.8"
+    "vite": "^5.2.8",
+    "web-haptics": "^0.0.6"
   },
   "devDependencies": {
     "oxfmt": "^0.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       vite:
         specifier: ^5.2.8
         version: 5.4.21(@types/node@18.19.130)
+      web-haptics:
+        specifier: ^0.0.6
+        version: 0.0.6(svelte@4.2.20)
     devDependencies:
       oxfmt:
         specifier: ^0.21.0
@@ -2574,6 +2577,23 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  web-haptics@0.0.6:
+    resolution: {integrity: sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+      svelte: '>=4'
+      vue: '>=3'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -5870,6 +5890,10 @@ snapshots:
   vscode-nls@5.2.0: {}
 
   vscode-uri@3.1.0: {}
+
+  web-haptics@0.0.6(svelte@4.2.20):
+    optionalDependencies:
+      svelte: 4.2.20
 
   web-namespaces@2.0.1: {}
 

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -64,5 +64,6 @@ const noteItems = noteSlugs.map(({ title, url }) => [title, url] as const);
     <script type="module">
 			import '/libraries/new-tag.js';
     </script>
+    <script src="../scripts/haptics.ts"></script>
   </body>
 </html>

--- a/src/scripts/haptics.ts
+++ b/src/scripts/haptics.ts
@@ -1,0 +1,20 @@
+import type { WebHaptics } from "web-haptics";
+
+let haptics: WebHaptics | null = null;
+
+async function getHaptics() {
+  if (haptics) return haptics;
+
+  const { WebHaptics } = await import("web-haptics");
+  if (!WebHaptics.isSupported) return null;
+
+  haptics = new WebHaptics();
+  return haptics;
+}
+
+document.addEventListener("click", (e) => {
+  const link = (e.target as HTMLElement).closest("nav a, header a");
+  if (!link) return;
+
+  getHaptics().then((h) => h?.trigger("nudge"));
+});


### PR DESCRIPTION
Lazy-loads the `web-haptics` library on first navigation click and triggers a "nudge" haptic pattern. The module is dynamically imported so it's never bundled upfront and is a no-op on unsupported browsers.