### PR TITLE
add note: taste is a proxy for science

### DIFF
--- a/src/pages/notes/taste-is-a-proxy-for-science.md
+++ b/src/pages/notes/taste-is-a-proxy-for-science.md
@@ -1,0 +1,35 @@
+---
+pubDate: March 31, 2026
+title: "Taste is a proxy for science"
+summary: And why the robots are coming for it
+tags: general
+layout: ../../layouts/Blog.astro
+---
+
+What is the thing we cannot automate? The differentiator between the generated slop and the curated product? It's taste, they say.
+
+But taste is hard to define. I think that's why people use it. You can hide behind the definition itself. Taste is the thing we've yet to fully describe. 
+
+I see this word mostly used in the guise of actual definitions. Designers, PMs, CEOs — they all possess taste. Engineers use this word more sparingly, for they wield the mighty "facts" that are their opinions. There is no need for taste when you can explain.
+
+But the outputs of "taste" are valuable. Many great designers and artists I've known would use this word. When pressed for the specific science of their decision making, you'd nary find a good take. It's mostly taste because the explanation is significantly more difficult.
+
+You can use taste to effectively hide the wrong opinion. By its nature, this word eludes critique and close inspection. It bundles a collection of feelings and strategies into a lump definition. You can take it or leave it - this is my taste and it is inscrutable. 
+
+The closest analogue I have is ye olde witch doctors. They brought medicines of various wisdoms (some folk, some fact). Perhaps some worked. Some had explanations. At the end you were at the mercy of the doctor's taste. They held something closer to the truth, after all.
+
+Eventually, the taste is discarded by peer review. In its place sit collections of strong anecdote, followed slowly by explanations of causality. You don't need taste forever.
+
+What people describe as taste I see as a gradient of abstraction. For now and for many problems we must defer to taste but only because the science is outside of our reach. Taste is for many purposes the right deference. It is right because nothing you can produce from hard thought will outmaneuver good intuition. 
+
+I don't think design is safe from technological automation.
+
+Taste is not safe because taste is temporary. Eventually we'll figure it out. When? I don't know. But the motivations are there; we'll get there.
+
+If you ask a modern LLM to produce a pretty website they'll do a decent job. A better job than they used to. Sure, this has yet to rival the talents of great designers, but it already beats out a whole bunch of amateurs. 
+
+Machine learning models are statistical black boxes. A lot of problems in computer science get revisited after the black box approach. If you reverse engineer the machine, you can optimize the process. The training produces a line of best-fit through an n-dimensional graph of data. It produces a line we didn't know could exist.
+
+I think we're seeing this line gain more definition. We don't have the words yet to describe it, but the model is finding patterns we have yet to vocalize.
+
+In lieu of better terms, the LLMs are developing taste, I fear.


### PR DESCRIPTION
Adds a new note exploring how taste is a temporary stand-in for science we haven't yet formalized, and what that means for design in the age of LLMs.