### PR TITLE
integrate standard.site sync and add note on impressive software

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Lint, Format, Typecheck, Build
@@ -16,22 +19,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         name: Install pnpm
         with:
           version: 10
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Lint
         run: pnpm run lint
@@ -44,4 +49,3 @@ jobs:
 
       - name: Build
         run: pnpm run build
-

--- a/.github/workflows/sync-standard-site.yml
+++ b/.github/workflows/sync-standard-site.yml
@@ -1,0 +1,34 @@
+name: Sync standard.site
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (no records written)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync publication and document records
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      BLUESKY_HANDLE: ${{ vars.BLUESKY_HANDLE }}
+      BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+      DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Sync
+        run: node scripts/sync-standard-site.mjs

--- a/public/blog/.well-known/site.standard.publication
+++ b/public/blog/.well-known/site.standard.publication
@@ -1,0 +1,1 @@
+at://did:plc:tgatoi47bb7xrxexwk7ogx73/site.standard.publication/blog

--- a/public/notes/.well-known/site.standard.publication
+++ b/public/notes/.well-known/site.standard.publication
@@ -1,0 +1,1 @@
+at://did:plc:tgatoi47bb7xrxexwk7ogx73/site.standard.publication/notes

--- a/scripts/sync-standard-site.mjs
+++ b/scripts/sync-standard-site.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+import { readFile, readdir } from "node:fs/promises";
+import { join, dirname, basename, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STANDARD_SITE_DID = "did:plc:tgatoi47bb7xrxexwk7ogx73";
+const PDS_URL = "https://bsky.social";
+
+const PUBLICATIONS = {
+  blog: {
+    rkey: "blog",
+    url: "https://emnudge.dev/blog",
+    name: "EmNudge Blog",
+    description: "Long-form articles on software, language, and the web.",
+  },
+  notes: {
+    rkey: "notes",
+    url: "https://emnudge.dev/notes",
+    name: "EmNudge Notes",
+    description: "Short notes and quick thoughts.",
+  },
+};
+
+const getDocumentRkey = (kind, slug) => `${kind}-${slug}`;
+const getPublicationAtUri = (kind) =>
+  `at://${STANDARD_SITE_DID}/site.standard.publication/${PUBLICATIONS[kind].rkey}`;
+
+const HANDLE = process.env.BLUESKY_HANDLE;
+const APP_PASSWORD = process.env.BLUESKY_APP_PASSWORD;
+const DRY_RUN = process.env.DRY_RUN === "1";
+
+if (!DRY_RUN && (!HANDLE || !APP_PASSWORD)) {
+  console.error("Missing BLUESKY_HANDLE or BLUESKY_APP_PASSWORD env vars");
+  process.exit(1);
+}
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const PAGES = {
+  blog: join(REPO_ROOT, "src/pages/blog"),
+  notes: join(REPO_ROOT, "src/pages/notes"),
+};
+
+const POST_EXTS = new Set([".md", ".mdx"]);
+
+const MAX_TITLE = 300;
+const MAX_SUMMARY = 1000;
+const MAX_TAGS = 16;
+const TAG_RE = /^[a-z0-9-]{1,32}$/i;
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+  const block = match[1];
+  const out = {};
+  let key = null;
+  for (const rawLine of block.split(/\r?\n/)) {
+    if (!rawLine.trim()) continue;
+    const indented = /^\s/.test(rawLine);
+    if (indented && key) {
+      const v = rawLine.trim();
+      if (!Array.isArray(out[key])) out[key] = [];
+      if (v.startsWith("-")) out[key].push(v.slice(1).trim());
+      continue;
+    }
+    const m = rawLine.match(/^([A-Za-z0-9_]+)\s*:\s*(.*)$/);
+    if (!m) continue;
+    key = m[1];
+    const rawVal = m[2].trim();
+    if (rawVal === "") {
+      out[key] = "";
+      continue;
+    }
+    out[key] = unquote(rawVal);
+  }
+  return out;
+}
+
+function unquote(v) {
+  if (
+    (v.startsWith('"') && v.endsWith('"')) ||
+    (v.startsWith("'") && v.endsWith("'"))
+  ) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+function toIsoDate(value) {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Unparseable pubDate: ${value}`);
+  }
+  return d.toISOString();
+}
+
+function sanitizeString(value, max) {
+  if (typeof value !== "string") return "";
+  const cleaned = value.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "").trim();
+  return cleaned.slice(0, max);
+}
+
+function sanitizeTags(value) {
+  const arr = typeof value === "string" ? [value] : Array.isArray(value) ? value : [];
+  return arr
+    .filter((t) => typeof t === "string" && TAG_RE.test(t))
+    .slice(0, MAX_TAGS);
+}
+
+async function loadPosts(kind) {
+  const dir = PAGES[kind];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = entries.filter(
+    (e) => e.isFile() && POST_EXTS.has(extname(e.name)),
+  );
+  const posts = [];
+  for (const entry of files) {
+    const slug = basename(entry.name, extname(entry.name));
+    const filePath = join(dir, entry.name);
+    const text = await readFile(filePath, "utf8");
+    const fm = parseFrontmatter(text);
+    if (!fm) {
+      console.warn(`skip ${kind}/${slug}: no frontmatter`);
+      continue;
+    }
+    if (fm.draft === "true" || fm.draft === true) continue;
+    if (!fm.title || !fm.pubDate) {
+      console.warn(`skip ${kind}/${slug}: missing title or pubDate`);
+      continue;
+    }
+    posts.push({
+      kind,
+      slug,
+      title: sanitizeString(fm.title, MAX_TITLE),
+      summary: sanitizeString(fm.summary, MAX_SUMMARY),
+      tags: sanitizeTags(fm.tags),
+      publishedAt: toIsoDate(fm.pubDate),
+      path: `/${kind}/${slug}`,
+    });
+  }
+  return posts;
+}
+
+async function createSession() {
+  const res = await fetch(`${PDS_URL}/xrpc/com.atproto.server.createSession`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ identifier: HANDLE, password: APP_PASSWORD }),
+  });
+  if (!res.ok) {
+    throw new Error(`createSession failed: HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+async function putRecord(session, collection, rkey, record) {
+  if (DRY_RUN) {
+    console.log(`[dry-run] putRecord ${collection}/${rkey}`);
+    return;
+  }
+  const res = await fetch(`${PDS_URL}/xrpc/com.atproto.repo.putRecord`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.accessJwt}`,
+    },
+    body: JSON.stringify({
+      repo: session.did,
+      collection,
+      rkey,
+      record,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `putRecord ${collection}/${rkey} failed: HTTP ${res.status}`,
+    );
+  }
+}
+
+async function main() {
+  const session = DRY_RUN
+    ? { did: STANDARD_SITE_DID, accessJwt: "" }
+    : await createSession();
+  if (session.did !== STANDARD_SITE_DID) {
+    throw new Error(
+      `DID mismatch: handle resolves to ${session.did} but script expects ${STANDARD_SITE_DID}`,
+    );
+  }
+
+  for (const kind of ["blog", "notes"]) {
+    const pub = PUBLICATIONS[kind];
+    await putRecord(session, "site.standard.publication", pub.rkey, {
+      $type: "site.standard.publication",
+      url: pub.url,
+      name: pub.name,
+      description: pub.description,
+    });
+    console.log(`✓ publication ${getPublicationAtUri(kind)}`);
+  }
+
+  const all = (
+    await Promise.all([loadPosts("blog"), loadPosts("notes")])
+  ).flat();
+  console.log(`syncing ${all.length} documents`);
+
+  for (const post of all) {
+    const rkey = getDocumentRkey(post.kind, post.slug);
+    await putRecord(session, "site.standard.document", rkey, {
+      $type: "site.standard.document",
+      site: getPublicationAtUri(post.kind),
+      title: post.title,
+      path: post.path,
+      description: post.summary || undefined,
+      publishedAt: post.publishedAt,
+      tags: post.tags.length ? post.tags : undefined,
+    });
+    console.log(`✓ ${post.kind}/${post.slug}`);
+  }
+
+  console.log(`done. ${all.length} documents synced.`);
+}
+
+main().catch((err) => {
+  console.error(err.message ?? "sync failed");
+  process.exit(1);
+});

--- a/src/data/standard-site.ts
+++ b/src/data/standard-site.ts
@@ -1,0 +1,32 @@
+export const STANDARD_SITE_DID = "did:plc:tgatoi47bb7xrxexwk7ogx73";
+
+export const PUBLICATIONS = {
+  blog: {
+    rkey: "blog",
+    url: "https://emnudge.dev/blog",
+    name: "EmNudge Blog",
+    description: "Long-form articles on software, language, and the web.",
+  },
+  notes: {
+    rkey: "notes",
+    url: "https://emnudge.dev/notes",
+    name: "EmNudge Notes",
+    description: "Short notes and quick thoughts.",
+  },
+} as const;
+
+export type PublicationKind = keyof typeof PUBLICATIONS;
+
+export const getDocumentRkey = (kind: PublicationKind, slug: string) => `${kind}-${slug}`;
+
+export const getPublicationAtUri = (kind: PublicationKind) =>
+  `at://${STANDARD_SITE_DID}/site.standard.publication/${PUBLICATIONS[kind].rkey}`;
+
+export const getDocumentAtUri = (kind: PublicationKind, slug: string) =>
+  `at://${STANDARD_SITE_DID}/site.standard.document/${getDocumentRkey(kind, slug)}`;
+
+export const getKindFromUrl = (url: string): PublicationKind | null => {
+  if (url.startsWith("/blog/")) return "blog";
+  if (url.startsWith("/notes/")) return "notes";
+  return null;
+};

--- a/src/layouts/Blog.astro
+++ b/src/layouts/Blog.astro
@@ -18,6 +18,7 @@ import {
 import "./blog/index.css";
 import Tooltip from "../components/Tooltip/Tooltip.astro";
 import { formatDate } from "../utils/formatDate";
+import { getDocumentAtUri, getKindFromUrl } from "../data/standard-site";
 
 interface Props {
 	content: {
@@ -53,6 +54,8 @@ const postItems = slugs.map(({ title, url }) => [title, url] as const);
 const noteSlugs = await Astro.glob("../pages/notes/*.md*").then(getSlugs);
 const noteItems = noteSlugs.map(({ title, url }) => [title, url] as const);
 const isNote = url.startsWith("/notes/");
+const standardSiteKind = getKindFromUrl(url);
+const standardSiteSlug = url.split("/").filter(Boolean).pop();
 import Toc from "../components/Toc.astro";
 ---
 <html lang="en">
@@ -76,6 +79,12 @@ import Toc from "../components/Toc.astro";
 		/>
 		<link rel="icon" href="/icons/icon_neon.webp" />
 		<link rel="stylesheet" href="/app.css" />
+		{standardSiteKind && standardSiteSlug && (
+			<link
+				rel="site.standard.document"
+				href={getDocumentAtUri(standardSiteKind, standardSiteSlug)}
+			/>
+		)}
 		<title>{title}</title>
 
 		<script type="application/ld+json" set:html={JSON.stringify({


### PR DESCRIPTION
Wire up standard.site (ATProto long-form publishing lexicons) and add a new note.

**standard.site integration**
- `src/data/standard-site.ts` — DID, two publications (blog + notes), AT-URI helpers
- `public/blog/.well-known/site.standard.publication` + same under notes — verification endpoints
- `src/layouts/Blog.astro` — injects `<link rel="site.standard.document" href="at://...">` per post
- `scripts/sync-standard-site.mjs` — Node script (no deps); auth, upsert publications, upsert one document per post; deterministic `<kind>-<slug>` rkeys so re-runs are free
- `.github/workflows/sync-standard-site.yml` — manual `workflow_dispatch` only

**Workflow hardening (sync + existing CI)**
- `permissions: contents: read` on both
- All third-party actions pinned to commit SHA with version comments
- `persist-credentials: false` on checkout
- Sync job gated to `refs/heads/main` only
- `pnpm install --ignore-scripts` in CI
- Sync script error paths log status only (no response-body echo)
- Frontmatter sanitization before forwarding to ATProto
- `BLUESKY_HANDLE` moved to `vars`; `BLUESKY_PDS_URL` hardcoded

**Note**
- `src/pages/notes/what-is-impressive-in-software.md`

**Required GitHub config before first run**
- Variable `BLUESKY_HANDLE` = `emnudge.dev`
- Secret `BLUESKY_APP_PASSWORD` = generated at bsky.app → Settings → App Passwords