### PR TITLE
add publication link tags for bluesky embed cards

### DIFF
--- a/src/layouts/Blog.astro
+++ b/src/layouts/Blog.astro
@@ -18,7 +18,11 @@ import {
 import "./blog/index.css";
 import Tooltip from "../components/Tooltip/Tooltip.astro";
 import { formatDate } from "../utils/formatDate";
-import { getDocumentAtUri, getKindFromUrl } from "../data/standard-site";
+import {
+	getDocumentAtUri,
+	getKindFromUrl,
+	getPublicationAtUri,
+} from "../data/standard-site";
 
 interface Props {
 	content: {
@@ -80,10 +84,16 @@ import Toc from "../components/Toc.astro";
 		<link rel="icon" href="/icons/icon_neon.webp" />
 		<link rel="stylesheet" href="/app.css" />
 		{standardSiteKind && standardSiteSlug && (
-			<link
-				rel="site.standard.document"
-				href={getDocumentAtUri(standardSiteKind, standardSiteSlug)}
-			/>
+			<>
+				<link
+					rel="site.standard.document"
+					href={getDocumentAtUri(standardSiteKind, standardSiteSlug)}
+				/>
+				<link
+					rel="site.standard.publication"
+					href={getPublicationAtUri(standardSiteKind)}
+				/>
+			</>
 		)}
 		<title>{title}</title>
 

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -3,8 +3,16 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import CommandPalette from "../components/CommandPalette/index.svelte";
 import { getSlugs } from "../data/blogs";
+import { getPublicationAtUri } from "../data/standard-site";
 
 const { title } = Astro.props;
+
+const pathname = Astro.url.pathname;
+const standardSitePubKind = pathname.startsWith("/blog")
+  ? "blog"
+  : pathname.startsWith("/notes")
+    ? "notes"
+    : null;
 
 const slugs = await Astro.glob("../pages/blog/*.md*").then(getSlugs);
 const postItems = slugs.map(({ title, url }) => [title, url] as const);
@@ -31,6 +39,12 @@ const noteItems = noteSlugs.map(({ title, url }) => [title, url] as const);
     />
     <link rel="icon" href="/icons/icon_neon.webp" />
     <link rel="stylesheet" href="/app.css" />
+    {standardSitePubKind && (
+      <link
+        rel="site.standard.publication"
+        href={getPublicationAtUri(standardSitePubKind)}
+      />
+    )}
 
     <title>{title}</title>
 


### PR DESCRIPTION
Per [bluesky-social/atproto#4978](https://github.com/bluesky-social/atproto/discussions/4978), Bluesky needs both `site.standard.document` and `site.standard.publication` link tags on post pages, plus a `site.standard.publication` link tag on each publication home page, to render enhanced link cards.

- `src/layouts/Blog.astro` — adds `<link rel="site.standard.publication">` alongside the existing document link on each post
- `src/layouts/Main.astro` — adds `<link rel="site.standard.publication">` when the path starts with `/blog` or `/notes`, so the index pages get tagged