### PR TITLE
add note: principles engineering

### DIFF
--- a/src/pages/notes/principles-engineering.md
+++ b/src/pages/notes/principles-engineering.md
@@ -1,0 +1,76 @@
+---
+pubDate: Jul 11, 2026
+title: "Principles engineering"
+summary: on building strategy and resolving conflict
+tags: general
+layout: ../../layouts/Blog.astro
+---
+
+
+When working with any number of people for long enough, assuming a healthy environment, you're going to have arguments. More than resolving conflict, it's really important to make decisions.
+
+You can call it strategy or philosophy, but I like calling it principles. Principles are how you resolve arguments. They're how you resolve arguments faster than you resolved them last time. They're how you accelerate decision-making.
+
+Principles are fundamental approaches to facts and problems that help accelerate decision-making. A principle should be a guiding philosophy on your next steps given a certain context.
+
+Without principles, arguments are mostly about how you feel at a given moment. They're not grounded in what's effective, and each argument is just as difficult as the last one.
+
+The most important thing to get right in the discussion is the landscape of facts. If you don't agree on the facts, you're not going to be very effective at moving anywhere.
+
+It's okay not to have all the facts, but you need to agree on your relationship to the lack or existence of facts, and exactly what the facts you agree exist are.
+
+So that I'm not just speaking in abstractions the whole time, let's give a concrete example.
+
+Let's assume you're building a mallet at your company, Mallets Incorporated. In trying to balance your approach to both marketing and effectiveness of the tool, you must now decide on the material for the handle. It's a rubber mallet. The mallet is going to be made of rubber, but the handle could be wood or some kind of metal. The specifics of the metal you have not decided yet. For now you just need to decide between wood and metal in general.
+
+Your co-founder thinks it should be metal. It gives the mallet a more premium feel and a distinction from lots of other mallets you can buy. You think it should be wood. Mallets have wooden handles. It's lighter and easier to hold, even if it looks less premium.
+
+Your co-founder thinks wood can splinter and that it doesn't differentiate the mallet from any other products on the market. You think metal makes it an ineffective tool and significantly heightens the cost of development.
+
+You're at a bit of a standstill, both of you having equal authority in this conversation.
+
+What would help here is a set of guiding principles. After some discussion, you agree on one of them.
+
+Our target audience is woodworkers. We are making mallets for woodworkers.
+
+This principle doesn't necessarily constrain your market potential, but it does directionally change your scope. You are not building mallets for the wider market. You are building them for a specific audience.
+
+Woodworkers are used to wooden handles. A woodworker, if well versed enough in their craft, would not settle for a metal handle even if it looks more premium.
+
+You go with wood.
+
+In software, your target audience tends to be a very important principle to settle early on, but it's not the only principle, just a very common one.
+
+Engineering strategy is a kind of principle. The book [The Engineering Executive's Primer](https://www.oreilly.com/library/view/the-engineering-executives/9781098149475/) talks a great deal about this. Whether you buy software or build software is a kind of engineering strategy and principle. What your bar is, is a kind of engineering strategy and principle. Whether you intend to build a bespoke product or one that is maximally flexible is an engineering strategy and principle. 
+
+As a designer or PM, there are lots of overlaps here. Engineering principles must influence your principles.
+
+Say the majority of your customers keep your website's tab open for days on end. This fundamentally changes how people interface with your product. It influences engineering strategy, a PM's investigation work, and a designer's approach to modeling that interface. A principle in this scenario would be to assume this as a correct current representation of your product and a directionally correct use of your product.
+
+In a large organization, you'll find that many principles do not yet exist. You might have principles within a specific product area that differ from the company's overall principles.
+
+It is therefore important to regularly update your principles internally. Very often you'll find a discussion between two people who do not agree on the correct principles. In these cases it's very important to have a reporting chain or some kind of decision maker who can specify and authoritatively define what the correct principle is in this context.
+
+If any two parties agree on the facts but are still arguing, it is almost certainly because there is a misalignment of principles.
+
+Before principles exist, it's not as important that you've gotten the correct principles but that your decision-making is based on principle foundations. What that specific principle is can be made up on the spot. Just choose something.
+
+Each subsequent argument is an opportunity to refine the principles that you've guessed at. Assuming an alignment on the facts, there must be a misalignment on the principles. Find out what those are and course correct.
+
+Over time you'll find the need to even have a discussion goes away. If you regularly agree on the facts and now regularly agree on the principles, there's not much decision-making left.
+
+This is also a really neat way to build copies of yourself within an organization. If you find yourself in a management position, ensuring your direct reports regularly agree on both the facts and principles allows you to unburden yourself from needing to get involved in daily discussions.
+
+The next time you're in an argument, or see an argument within your boundary, try to assess why that argument is happening.
+
+Is it a disagreement on the facts? Create rich analytics and start investigations. Make sure this is impossible. Everyone must agree on the facts.
+
+If there is still an argument, this is a misalignment of principles. Find what those principles are and make a decision. Your organization should be bought into these specific principles.
+
+Some organizations are built upon a series of hidden principles. You can call this politics, really dense politics.
+
+An example of a hidden politic might be that your principal goal is to appear productive rather than to create an important product. It could be that the point is for other teams to recognize your team as noteworthy, as popular.
+
+These are the kind of principles that companies are embarrassed to make public. There are also principles that a VP would be upset to learn about, but it's a culture they almost certainly fostered.
+
+My advice here is simply to change companies. Those places kind of suck to work at.


### PR DESCRIPTION
New note on using principles to resolve arguments and accelerate decision-making, with a mallet-manufacturing example and application to engineering strategy.