### PR TITLE
make theme toggle respect system preference with clearable override

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -33,8 +33,10 @@ body {
 	margin: 0;
 }
 
+/* System light preference, unless the user has explicitly forced dark
+   (the .dark override must win over the media query). */
 @media (prefers-color-scheme: light) {
-	:root {
+	:root:not(.dark) {
 		--active: #ff7b3a;
 		--light-active: #ffdac8;
 		--foreground: #222;
@@ -47,13 +49,13 @@ body {
 		--bg-light-transparent: #eee5;
 		--box-shadow-light-only: 2px 2px 3px #00000038;
 	}
-	body {
+	:root:not(.dark) body {
 		background: linear-gradient(to bottom right, white, #f8f9fb);
 	}
-	img.dark-mode {
+	:root:not(.dark) img.dark-mode {
 		filter: invert(1);
 	}
-	::selection {
+	:root:not(.dark) ::selection {
 		background: #ffb7b7;
 	}
 }

--- a/src/components/CommandPalette/index.svelte
+++ b/src/components/CommandPalette/index.svelte
@@ -54,9 +54,27 @@ function buildCommands(
       id: "Theme",
       title: "Toggle Theme",
       handler: () => {
-        document.documentElement.classList.toggle("light");
-        const isLight = document.documentElement.classList.contains("light");
-        localStorage.setItem("theme", isLight ? "light" : "dark");
+        // Respect the system theme unless the user picks against it. Toggling
+        // flips to the opposite of what's shown; if that lands back on the
+        // system preference, the override is cleared so we follow the system.
+        const root = document.documentElement;
+        const system = window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+        const current = root.classList.contains("light")
+          ? "light"
+          : root.classList.contains("dark")
+            ? "dark"
+            : system;
+        const target = current === "dark" ? "light" : "dark";
+
+        root.classList.remove("light", "dark");
+        if (target === system) {
+          localStorage.removeItem("theme");
+        } else {
+          root.classList.add(target);
+          localStorage.setItem("theme", target);
+        }
       },
     },
     {
@@ -414,25 +432,25 @@ onDestroy(() => {
 
   /* Light mode styles */
   @media (prefers-color-scheme: light) {
-    .palette {
+    :global(:root:not(.dark)) .palette {
       background: rgba(255, 255, 255, 0.95);
       border: 1px solid #ddd;
       box-shadow: 0 4px 30px rgba(0, 0, 0, 0.15);
     }
-    .search-input {
+    :global(:root:not(.dark)) .search-input {
       border-bottom-color: #eee;
     }
-    .back-button {
+    :global(:root:not(.dark)) .back-button {
       border-bottom-color: #eee;
     }
-    .command-item:hover,
-    .command-item.selected {
+    :global(:root:not(.dark)) .command-item:hover,
+    :global(:root:not(.dark)) .command-item.selected {
       background: #f5f5f5;
     }
-    .footer {
+    :global(:root:not(.dark)) .footer {
       border-top-color: #eee;
     }
-    kbd {
+    :global(:root:not(.dark)) kbd {
       background: #f0f0f0;
       border: 1px solid #ddd;
     }

--- a/src/components/ProjectStub.astro
+++ b/src/components/ProjectStub.astro
@@ -55,7 +55,7 @@ const { url, icon, name, description } = Astro.props;
     box-shadow: 0 0 10px 0 #0001;
   }
   @media (prefers-color-scheme: light) {
-    .project:hover {
+    html:not(.dark) .project:hover {
       border-color: #0004;
       box-shadow: 0 0 10px 0 #0001;
     }

--- a/src/components/Stub.astro
+++ b/src/components/Stub.astro
@@ -90,10 +90,10 @@ const {
         display: none;
     }
     @media (prefers-color-scheme: light) {
-        .discussions .icon-dark {
+        :global(:root:not(.dark)) .discussions .icon-dark {
             display: none;
         }
-        .discussions .icon-light {
+        :global(:root:not(.dark)) .discussions .icon-light {
             display: block;
         }
     }

--- a/src/layouts/Blog.astro
+++ b/src/layouts/Blog.astro
@@ -70,9 +70,12 @@ import Toc from "../components/Toc.astro";
 		<meta name="author" content="EmNudge" />
 		<meta name="keywords" content="EmNudge" />
 		<meta name="color-scheme" content="dark light" />
-		<script>
-			if (localStorage.getItem("theme") === "light") {
-				document.documentElement.classList.add("light");
+		<script is:inline>
+			// Re-apply an explicit theme override the user set against their system
+			// preference. No stored value means we follow the system (handled in CSS).
+			const theme = localStorage.getItem("theme");
+			if (theme === "light" || theme === "dark") {
+				document.documentElement.classList.add(theme);
 			}
 		</script>
 		<link
@@ -314,10 +317,10 @@ import Toc from "../components/Toc.astro";
     display: none;
   }
   @media (prefers-color-scheme: light) {
-    .discussions .icon-dark {
+    :global(:root:not(.dark)) .discussions .icon-dark {
       display: none;
     }
-    .discussions .icon-light {
+    :global(:root:not(.dark)) .discussions .icon-light {
       display: block;
     }
   }

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -31,6 +31,15 @@ const noteItems = noteSlugs.map(({ title, url }) => [title, url] as const);
     <meta name="keywords" content="EmNudge" />
     <meta name="color-scheme" content="dark light" />
 
+    <script is:inline>
+      // Re-apply an explicit theme override the user set against their system
+      // preference. No stored value means we follow the system (handled in CSS).
+      const theme = localStorage.getItem("theme");
+      if (theme === "light" || theme === "dark") {
+        document.documentElement.classList.add(theme);
+      }
+    </script>
+
     <link
       rel="alternate"
       type="application/rss+xml"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -126,7 +126,7 @@ const videos = await getVideos();
   }
 
   @media (prefers-color-scheme: light) {
-    .newest-blog {
+    :root:not(.dark) .newest-blog {
       --highlight: #ffdbbd
     }
   }


### PR DESCRIPTION
Adopts the system-aware two-state toggle technique from [Lea Verou's dark mode toggles post](https://lea.verou.me/blog/2026/dark-mode-toggles/): the theme follows the OS by default, and only stores an override when the user picks *against* their system preference. Toggling back to the system value clears the override so the site resumes following the system.

## Changes
- **Toggle logic** (`CommandPalette`): flip to the opposite of what's shown; if the target equals the system preference, `removeItem("theme")` and drop the class, otherwise store the override. Also fixes a latent bug where the old toggle manipulated a `.light` class that the media query (not a class) controlled, so it never worked on a light-OS machine.
- **Restore scripts** (`Main.astro`, `Blog.astro`): the blocking inline script now re-applies either a `light` or `dark` override before first paint (previously only `light`), avoiding a flash.
- **CSS** (`app.css` + `Stub`, `ProjectStub`, `CommandPalette`, `Blog`, `index`): gated every `@media (prefers-color-scheme: light)` block with `:not(.dark)` so a forced-dark override fully wins over system-light — previously only a forced-light path existed.

The mermaid renderer needs no change: it reads the resolved `--background` variable and re-renders on class/media changes, so it follows all four states automatically.